### PR TITLE
Fix JSON response for status API to include user information and fix 500 error

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -8,7 +8,7 @@ class StatusesController < ApplicationController
     @statuses = Status.includes(:user).paginate(:page => params[:page], :per_page => 10, :order => "created_at DESC")
     respond_to do |format|
       format.html
-      format.js
+      format.json
     end
   end
 

--- a/app/views/statuses/index.json.jbuilder
+++ b/app/views/statuses/index.json.jbuilder
@@ -1,4 +1,8 @@
 json.array!(@statuses) do |status|
-  json.extract! status, :name, :content
+  json.extract! status, :content
+  json.user do
+    json.id status.user_id
+    json.username status.user.profile_name
+  end
   json.url status_url(status, format: :json)
 end

--- a/app/views/statuses/show.json.jbuilder
+++ b/app/views/statuses/show.json.jbuilder
@@ -1,1 +1,5 @@
-json.extract! @status, :name, :content, :created_at, :updated_at
+json.(@status, :content, :created_at, :updated_at)
+json.user do
+  json.id @status.user_id
+  json.username @status.user.profile_name
+end


### PR DESCRIPTION
I've fixed several 500 errors regarding status json API. Here's a sample output for a single status. Let me know what you think.

``` json
{
    "content": "Here's a status....",
    "created_at": "2014-04-12T11:12:13.463Z",
    "updated_at": "2014-04-12T11:12:13.463Z",
    "user": {
        "id": 1,
        "username": "rcdilorenzo"
    }
}
```
